### PR TITLE
Add support for 2023.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ You can download the plugin "**testCherry**" directly from the IDE.
 * run ```gradlew build```
 
 <h2>Change Notes</h2>
+**3.12**
+* Add support for IntelliJ IDEA version **2023.2**
 **3.11**
 * Add support for IntelliJ IDEA version **2023.1**
 **3.10**
@@ -100,7 +102,6 @@ You can download the plugin "**testCherry**" directly from the IDE.
 * Add support for IntelliJ IDEA version **2022.2**
 **3.8**
 * Add support for IntelliJ IDEA version **2021.3**
-
 **3.7**
 * Add support for IntelliJ IDEA version **2021.2**
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,20 +4,20 @@
 pluginGroup = com.blacknebula
 pluginName = TestCherry
 # SemVer format -> https://semver.org
-pluginVersion = 3.11
+pluginVersion = 3.12
 
 
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 231
-pluginUntilBuild = 231.*
+pluginSinceBuild = 230
+pluginUntilBuild = 232.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 ## https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-type
 platformType = IC
 ## https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#intellij-platform-based-products-of-recent-ide-versions
-platformVersion = 2023.1
+platformVersion = 2023.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
@@ -27,4 +27,4 @@ platformPlugins = com.intellij.java
 javaVersion = 17
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 7.5.1
+gradleVersion = 7.6.2

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.blacknebula.TestCherry</id>
     <name>TestCherry</name>
-    <version>3.11</version>
+    <version>3.12</version>
 
     <vendor email="benkhalfallahhazem@gmail.com"
             url="https://github.com/Hazem-Ben-Khalfallah/test-cherry">
@@ -10,7 +10,7 @@
 
     <!-- Upgrade this version to support newer version of intellij IDE
     please see: https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#intellij-platform-based-products-of-recent-ide-versions-->
-    <idea-version since-build="231" until-build="231.*"/>
+    <idea-version since-build="230" until-build="232.*"/>
 
     <description><![CDATA[
     <b>About</b>


### PR DESCRIPTION
add support for the new version of IntelliJ 2023.2 and allow usage from a version back