### PR TITLE
added support to build 242.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
 # IntelliJ Platform Plugin Template Changelog
+## [3.17]
+### Changed
+- Support build range `242.*`
+
 ## [3.16]
 ### Changed
 - Specify plugin display name in settings. Move plugin config under `Settings > Tools`

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ You can download the plugin "**testCherry**" directly from the IDE.
 * run ```gradlew build```
 
 <h2>Change Notes</h2>
+**3.17**
+* Support build range `242.*`
+
 **3.16**
 * Specify plugin display name in settings. Move plugin config under `Settings > Tools`
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,14 @@
 pluginGroup = com.blacknebula
 pluginName = TestCherry
 # SemVer format -> https://semver.org
-pluginVersion = 3.16
+pluginVersion = 3.17
 
 
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 230
-pluginUntilBuild = 241.*
+pluginUntilBuild = 242.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 ## https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-type


### PR DESCRIPTION
since all of my students use the latest version of intellij all the time, I think TestCherry plugin version needs to be updated for this new version.
Installed and tested it on Build #IU-242.23726.103, built on October 23, 2024  and older build Build #IU-232.10335.12, built on September 5, 2024

This is the first time I've made a change to a plugin, so anything I forgot to do or any recommendations to do it better are welcome.